### PR TITLE
Add command to auto-start service

### DIFF
--- a/platforms/ubuntu/install.sh
+++ b/platforms/ubuntu/install.sh
@@ -30,8 +30,7 @@ hostnamectl set-hostname jackcast
 apt-get install -y avahi-daemon
 
 
-apt install -y nginx\
-    uwsgi
+apt install -y nginx
 
 apt install -y\
     build-essential\
@@ -43,4 +42,10 @@ apt install -y\
 
 # Allow HTTP traffic
 ufw allow 'Nginx HTTP'
+
+# Since PulseAudio and Jackcast are running as a user service
+# we need to make sure the services start on boot. We can do this
+# by enable linger per this document,
+# https://wiki.archlinux.org/index.php/Systemd/User#Automatic_start-up_of_systemd_user_instances
+loginctl enable-linger $USER
 


### PR DESCRIPTION
Closes: #4 Fixes bug where the Gunicorn server was not started until
user logged in. Now it starts on boot.